### PR TITLE
Removing install dependency on python-kaleido

### DIFF
--- a/piqqa-conda-install.txt
+++ b/piqqa-conda-install.txt
@@ -3,4 +3,3 @@ numpy=1.21.0
 requests= 2.25.1
 matplotlib= 3.4.2
 plotly=5.1.0
-python-kaleido=0.2.1


### PR DESCRIPTION
Users were having issues installing python-kaleido on Apple M1 machines (https://github.com/iris-edu/piqqa/issues/1). Turns out, the dependency for that install is a relic of an earlier version of the code and can be done without.  So it has been removed from the install file.