### PR TITLE
Fix issue 3

### DIFF
--- a/PIQQA.py
+++ b/PIQQA.py
@@ -24,7 +24,7 @@ under the License.
 
 '''
 
-version = 'v1.0.0'
+version = 'v1.0.1'
 
 import reportUtils
 import pandas as pd

--- a/reportUtils.py
+++ b/reportUtils.py
@@ -168,11 +168,11 @@ def addMetricToDF(metric, DF, network, stations, locations, channels, startDate,
         print(f"        Retrieving {metric}")
     chanList = list()
     for chan in channels.split(','):
-        if len(chan) == 2:
-#             chan = f"{chan}Z,{chan}1"
+        if (len(chan) == 3) and (chan[2] in ['*', '?', '.', '_']):
+            chan = f'{chan[0:2]}Z'
+        elif len(chan) == 2:
             chan = f"{chan}Z"
-        if chan == "*":
-#             chan = "??Z,??1"
+        elif chan == "*":
             chan = "??Z"
         chanList.append(chan)
     
@@ -225,10 +225,12 @@ def getMetadata(network, stations, locations, channels, startDate, endDate, leve
      
     chanList = list()
     for chan in channels.split(','):
-        if len(chan) == 2:
+        if (len(chan) == 3) and (chan[2] in ['*', '?', '.', '_']):
+            chan = f'{chan[0:2]}Z'
+        elif len(chan) == 2:
 #             chan = f"{chan}Z,{chan}1"
             chan = f"{chan}Z"
-        if chan == "*":
+        elif chan == "*":
 #             chan = "??Z,??1"
             chan = "??Z"
         chanList.append(chan)


### PR DESCRIPTION
Fixing https://github.com/iris-edu/piqqa/issues/3, where the same channel group would be repeated in each section of the report if the user supplied a 3-character channel code and the final character was a wildcard (ex: BH?).  This will now be treated as if it were a 2-character code (ex: BH).  Cases where the user supplies 2-letter codes (BH, B?) or omits a channel filter altogether, have not changed behavior. 