### PR TITLE
PDF bug fix, improved handling for missing metrics

### DIFF
--- a/PIQQA.py
+++ b/PIQQA.py
@@ -625,14 +625,14 @@ def doBoxPlots(splitPlots, metricList, metricsRequired, network, stations, locat
             tmpDF = scaledDF[scaledDF['target'].str.endswith(channelGroup)]
             grouped = tmpDF.groupby(['station'])
             
-            
             filenames = list()
             for metric in metricList:
+                if metric == 'sample_rms':
+                    metric = "scale_corrected_sample_rms"
                 if metric not in tmpDF.columns:
                     continue
                 fig = plt.Figure(figsize=(3,  0.2*nBoxPlotSta))
-                if metric == 'sample_rms':
-                    metric = "scale_corrected_sample_rms"
+                
                 
                 try:
                     # This may fail if the metric wasn't accessible from web services

--- a/PIQQA.py
+++ b/PIQQA.py
@@ -518,14 +518,19 @@ def doBoxPlots(splitPlots, metricList, metricsRequired, network, stations, locat
     for metric in metricsRequired:
         metricDF = reportUtils.addMetricToDF(metric, metricDF, network, stations, locations, channels, startDate, endDate)
     
+    
     if metricDF.empty:
-        print(f"**** WARNING: No metrics retrieved for {network}.{stations}.{locations}.{channels} {startDate}-{endDate} - services could be down or metrics may not exist for data yet ****")
+        print(f"        WARNING: No metrics retrieved for {network}.{stations}.{locations}.{channels} {startDate}-{endDate} - services could be down or metrics may not exist for data yet")
         boxPlotDictionary = {}
         actualChannels = list()
         scaledDF = pd.DataFrame()
         splitPlots = False
-        
+
     else:
+        if 'sample_rms' not in metricDF.columns:
+            print(f"        WARNING: No sample_rms metrics retrieved for {network}.{stations}.{locations}.{channels} {startDate}-{endDate} - metrics may not exist for data yet")  
+            print(f"        WARNING: Will not be able to select PDFs or Spectrograms")
+        
         # Create a list of all channels that actually have metrics
         actualChannels = sorted(list(set([x[3] for x in metricDF['target'].str.split('.')])))    
         actualChannelsText = ','.join(actualChannels)
@@ -594,7 +599,7 @@ def doBoxPlots(splitPlots, metricList, metricsRequired, network, stations, locat
 
         scaledDF= metricDF.copy()   
         # scale sample_rms by "scale" from station ws
-        if 'sample_rms' in metricList:
+        if 'sample_rms' in scaledDF.columns:
             print("    INFO: Applying scale factor to sample_rms")
 
             try:
@@ -623,6 +628,8 @@ def doBoxPlots(splitPlots, metricList, metricsRequired, network, stations, locat
             
             filenames = list()
             for metric in metricList:
+                if metric not in tmpDF.columns:
+                    continue
                 fig = plt.Figure(figsize=(3,  0.2*nBoxPlotSta))
                 if metric == 'sample_rms':
                     metric = "scale_corrected_sample_rms"

--- a/reportUtils.py
+++ b/reportUtils.py
@@ -157,6 +157,10 @@ def retrieveMetrics(URL, metric):
     tempDF['start'] = pd.to_datetime(tempDF['start'])
     tempDF['end'] = pd.to_datetime(tempDF['end'])
     
+    if metric == "sample_rms" and tempDF.empty:
+        print(f"             --> Unable to get measurements for {metric}")
+        print(f"             {URL}")
+    
     return tempDF
 
 def addMetricToDF(metric, DF, network, stations, locations, channels, startDate, endDate):
@@ -320,6 +324,8 @@ def getPDF(target, startDate, endDate, spectPowerRange, imageDir):
     net = target.split('.')[0]
     sta = target.split('.')[1]
     loc = target.split('.')[2]
+    if loc == '':
+        loc = '--'
     cha = target.split('.')[3]
     
     
@@ -398,10 +404,16 @@ def getBoundsZoomLevel(bounds, mapDim):
     
         lngDiff = e_long - w_long
         lngFraction = ((lngDiff + 360) if lngDiff < 0 else lngDiff) / 360
+        lat_lng_fraction = max(latFraction, lngFraction) / min(latFraction, lngFraction)
     
         latZoom = zoom(mapDim['height'], WORLD_DIM['height'], latFraction)
         lngZoom = zoom(mapDim['width'], WORLD_DIM['width'], lngFraction)
-        return min(max(latZoom, lngZoom, ZOOM_MIN), ZOOM_MAX)
+        zoomDiff = max(latZoom, lngZoom)
+        
+        if lat_lng_fraction > 10:
+            zoomDiff = max(latZoom, lngZoom) - min(latZoom, lngZoom)
+            
+        return min(max(zoomDiff, ZOOM_MIN), ZOOM_MAX)
     
     
 def getMetricLabel(metric):


### PR DESCRIPTION
The code updates do 3 things:

1. Fix a bug that was preventing PDF retrieval when looking for channels with empty location codes 
2. Improved handing and messaging for situations where metrics might be missing, especially sample_rms.  It used to stop and not produce a report at all, and now it will continue with report generation - It will contain the availability plot(s), boxplots for any metrics it could retrieve (such as the on-the-fly availability metrics), and the map and station table.  Because sample_rms is required for selecting the PDFs and spectrograms, if the metric is missing then it will not include PDFs or spectrograms. Odds are if sample_rms is missing, so are the PDFs anyway.
3. Slight alteration to the default zoom level in the map.  Most cases will have the same default zoom as they did before, but for cases where the stations are distributed in a very long, narrow band the original zoom algorithm was not ideal. So there is now a catch for cases like that.  